### PR TITLE
Add shim for cordova-plugin-dialogs

### DIFF
--- a/addon/services/dialogs.js
+++ b/addon/services/dialogs.js
@@ -1,0 +1,207 @@
+import Ember from 'ember';
+import missingPlugin from '../utils/missing-plugin';
+
+/**
+  Service that allows for displaying native dialogs for user interaction.
+
+  Configuration and setup of the service is done in an initializer:
+
+  ```javascript
+  import DialogsService from 'cordova-shims/services/dialogs';
+
+  export function initialize(container, application) {
+    application.register('service:dialogs', DialogsService);
+    application.inject('route', 'dialogs', 'service:dialogs');
+  }
+
+  export default {
+    name: 'dialogs-service',
+    initialize: initialize
+  };
+  ```
+
+  The service has an interface for defining custom fallback methods for each
+  dialog type.
+
+  - alertFallback
+  - confirmFallback
+  - promptFallback
+
+  If your app targets both browser and native platforms, you should provide your
+  own implementation of these fallbacks methods. There are simple default methods
+  defined to get you started quickly.
+
+  @class Dialogs
+  @namespace CordovaShims.Services
+  @module cordova-shims/services/dialogs
+  @extends Ember.Service
+  @since 0.2.0
+ */
+export default Ember.Service.extend({
+  init: function(){
+    if (!window.navigator.notification) {
+      missingPlugin('cordova-plugin-dialogs', 'https://github.com/apache/cordova-plugin-dialogs.git');
+    }
+  },
+
+  /**
+    Display an alert box to the user with a title, message and a customizable button name.
+
+    Example:
+
+    ```javascript
+    DialogsService.create().alert({
+      title: 'Something important',
+      message: 'This just happened!',
+      button: 'OK'
+    });
+    ```
+
+    @method alert
+    @param {Object} options
+    @param {String} options.title Title for the alert box
+    @param {String} options.message Message to show in the alert box
+    @param {String} options.button Text for the button that dismisses the alert box
+    @return {RSVP.Promise} A promise that will resolve when alert is dismissed.
+  */
+  alert: function(options){
+    let { title, message, button } = options;
+
+    if (!window.navigator.notification) {
+      return Ember.RSVP.resolve(this.alertFallback(message, title, button));
+    }
+
+    return new Ember.RSVP.Promise(function(resolve){
+      window.navigator.notification.alert(message, resolve, title, button);
+    });
+  },
+
+  /**
+    Display a confirm box to the user with a title, message and customizable button names.
+
+    Example:
+
+    ```javascript
+    DialogsService.create().confirm({
+      title: 'Something important',
+      message: 'This just happened!',
+      buttons: [
+        'OK',
+        'Cancel'
+      ]
+    });
+    ```
+
+    @method confirm
+    @param {Object} options
+    @param {String} options.title Title for the confirm box
+    @param {String} options.message Message to show in the confirm box
+    @param {Array} options.buttons Text for the button that dismisses the confirm box
+    @return {RSVP.Promise} A promise that will resolve with the index of the button pressed (1-indexed).
+  */
+  confirm: function(options){
+    let { title, message, buttons } = options;
+
+    if (!window.navigator.notification) {
+      return Ember.RSVP.resolve(this.confirmFallback(message, title, buttons));
+    }
+
+    return new Ember.RSVP.Promise(function(resolve){
+      window.navigator.notification.confirm(message, resolve, title, buttons);
+    });
+  },
+
+
+  /**
+    Display a prompt to the user with a title, message, text input and a customizable button name.
+
+    Example:
+
+    ```javascript
+    DialogsService.create().prompt({
+      title: 'Please provide some info',
+      message: 'We need to know something.',
+      defaultText: 'foo',
+      buttons: [
+        'OK',
+        'Cancel'
+      ]
+    });
+    ```
+
+    @method prompt
+    @param {Object} options
+    @param {String} options.title Title for the confirm box
+    @param {String} options.message Message to show in the confirm box
+    @param {Array} options.buttons Text for the button that dismisses the confirm box
+    @return {RSVP.Promise} A promise that will resolve with the following:
+
+        {
+          text: "{text-from-input}",
+          buttonIndex: 1 // Index of the button pressed
+        }
+  */
+  prompt: function(options){
+    let { title, message, buttons, defaultText } = options;
+
+    if (!window.navigator.notification) {
+      return Ember.RSVP.resolve(this.promptFallback(message, title, buttons, defaultText));
+    }
+
+    return new Ember.RSVP.Promise(function(resolve){
+      let callback = function(result){
+        let { input1, buttonIndex } = result;
+        resolve({ text: input1, buttonIndex });
+      };
+      window.navigator.notification.prompt(message, callback, title, buttons, defaultText);
+    });
+  },
+
+  /**
+    Hook that gets triggered if the plugin API is not available. Useful for handling
+    dialogs in a browser environment.
+
+    @property alertFallback
+    @type Function
+  */
+  alertFallback: function(message, title, buttonName){
+    Ember.Logger.warn('Using alert fallback for cordova dialogs shim.');
+    Ember.Logger.warn('You should override the alertFallback method in the dialogs service.');
+    window.alert(title+"\n"+message+"\n\n"+buttonName);
+  },
+
+  /**
+    Hook that gets triggered if the plugin API is not available. Useful for handling
+    dialogs in a browser environment.
+
+    @property confirmFallback
+    @type Function
+  */
+  confirmFallback: function(message, title, buttonLabels){
+    Ember.Logger.warn('Using confirm fallback for cordova dialogs shim.');
+    Ember.Logger.warn('You should override the confirmFallback method in the dialogs service.');
+    if (window.confirm(title+"\n"+message+"\n\n"+buttonLabels.join(" "))) {
+      return 1;
+    } else {
+      return 2;
+    }
+  },
+
+  /**
+    Hook that gets triggered if the plugin API is not available. Useful for handling
+    dialogs in a browser environment.
+
+    @property promptFallback
+    @type Function
+  */
+  promptFallback: function(message, title, buttonLabels, defaultText){
+    Ember.Logger.warn('Using confirm fallback for cordova dialogs shim.');
+    Ember.Logger.warn('You should override the promptFallback method in the dialogs service.');
+    let text = window.prompt(title+"\n"+message+"\n\n"+buttonLabels.join(" "), defaultText);
+    let buttonIndex = 1;
+    if (!text) {
+      buttonIndex = 2;
+    }
+    return { buttonIndex, text };
+  }
+});

--- a/addon/services/notifications.js
+++ b/addon/services/notifications.js
@@ -35,6 +35,7 @@ const missingPlugin = function(name, src){
   @namespace CordovaShims.Services
   @module cordova-shims/services/notifications
   @extends Ember.Service
+  @since 0.1.0
  */
 export default Em.Service.extend(Em.Evented, {
   /**

--- a/addon/services/notifications.js
+++ b/addon/services/notifications.js
@@ -1,9 +1,5 @@
 import Em from 'ember';
-
-const missingPlugin = function(name, src){
-  Em.Logger.warn("Missing Cordova Plugin: "+name+"\n"+
-                 "Install with: cordova plugin add "+src);
-};
+import missingPlugin from '../utils/missing-plugin';
 
 /**
   Service that allows for registration/unregistration and handling of push

--- a/addon/utils/missing-plugin.js
+++ b/addon/utils/missing-plugin.js
@@ -1,0 +1,4 @@
+export default function function(name, src){
+  Em.Logger.warn("Missing Cordova Plugin: "+name+"\n"+
+                 "Install with: cordova plugin add "+src);
+}

--- a/app/services/dialogs.js
+++ b/app/services/dialogs.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-cordova-shims/services/dialogs';

--- a/tests/unit/services/dialogs-test.js
+++ b/tests/unit/services/dialogs-test.js
@@ -1,0 +1,162 @@
+import { moduleFor, test } from 'ember-qunit';
+/* global expect */
+
+moduleFor('service:dialogs', 'Unit | Service | dialogs', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+test('alert | cordova', function(assert) {
+  var service = this.subject();
+  expect(4);
+
+  window.navigator.notification = {};
+  window.navigator.notification.alert = function(message, alertCallback, title, buttonName){
+    assert.equal(message, 'Some alert message');
+    assert.equal(title, 'Title');
+    assert.equal(buttonName, 'OK');
+    alertCallback();
+  };
+
+  service.alert({
+    title: 'Title',
+    message: 'Some alert message',
+    button: 'OK'
+  }).then(function(){
+    assert.ok(true);
+  });
+});
+
+test('alert | fallback', function(assert) {
+  var service = this.subject({
+    alertFallback: function(message, title, buttonName){
+      assert.equal(message, 'Some alert message');
+      assert.equal(title, 'Title');
+      assert.equal(buttonName, 'OK');
+    }
+  });
+  expect(4);
+
+  delete(window.navigator.notification);
+
+  service.alert({
+    title: 'Title',
+    message: 'Some alert message',
+    button: 'OK'
+  }).then(function(){
+    assert.ok(true);
+  });
+});
+
+test('confirm | cordova', function(assert) {
+  var service = this.subject();
+  expect(4);
+
+  window.navigator.notification = {};
+  window.navigator.notification.confirm = function(message, confirmCallback, title, buttonLabels) {
+    assert.equal(message, 'Something to confirm');
+    assert.equal(title, 'Confirm');
+    assert.deepEqual(buttonLabels, ['OK', 'Cancel']);
+    confirmCallback(1); // Pressed OK
+  };
+
+  service.confirm({
+    title: 'Confirm',
+    message: 'Something to confirm',
+    buttons: [
+      'OK',
+      'Cancel'
+    ]
+  }).then(function(buttonIndex){
+    assert.equal(buttonIndex, 1);
+  });
+});
+
+test('confirm | fallback', function(assert) {
+  var service = this.subject({
+    confirmFallback: function(message, title, buttonLabels){
+      assert.equal(message, 'Something to confirm');
+      assert.equal(title, 'Confirm');
+      assert.deepEqual(buttonLabels, ['OK', 'Cancel']);
+
+      return 1; // Simulate pressed OK
+    }
+  });
+  expect(4);
+
+  delete(window.navigator.notification);
+
+  service.confirm({
+    title: 'Confirm',
+    message: 'Something to confirm',
+    buttons: [
+      'OK',
+      'Cancel'
+    ]
+  }).then(function(buttonIndex){
+    assert.equal(buttonIndex, 1);
+  });
+});
+
+test('prompt | cordova', function(assert) {
+  var service = this.subject();
+  expect(6);
+
+  window.navigator.notification = {};
+  window.navigator.notification.prompt = function(message, promptCallback, title, buttonLabels, defaultText) {
+    assert.equal(message, 'Something to write');
+    assert.equal(title, 'Prompt');
+    assert.equal(defaultText, 'foo');
+    assert.deepEqual(buttonLabels, ['OK', 'Cancel']);
+    promptCallback({
+      buttonIndex: 1,
+      input1: 'bar'
+    }); // Pressed OK
+  };
+
+  service.prompt({
+    title: 'Prompt',
+    message: 'Something to write',
+    defaultText: 'foo',
+    buttons: [
+      'OK',
+      'Cancel'
+    ]
+  }).then(function(result){
+    let { buttonIndex, text } = result;
+    assert.equal(buttonIndex, 1);
+    assert.equal(text, 'bar');
+  });
+});
+
+test('prompt | fallback', function(assert) {
+  var service = this.subject({
+    promptFallback: function(message, title, buttonLabels, defaultText){
+      assert.equal(message, 'Something to write');
+      assert.equal(title, 'Prompt');
+      assert.equal(defaultText, 'foo');
+      assert.deepEqual(buttonLabels, ['OK', 'Cancel']);
+      return {
+        text: 'bar',
+        buttonIndex: 1 // Simulate pressed OK
+      };
+    }
+  });
+  expect(6);
+
+  delete(window.navigator.notification);
+
+  service.prompt({
+    title: 'Prompt',
+    message: 'Something to write',
+    defaultText: 'foo',
+    buttons: [
+      'OK',
+      'Cancel'
+    ]
+  }).then(function(result){
+    let { text, buttonIndex } = result;
+    assert.equal(buttonIndex, 1);
+    assert.equal(text, 'bar');
+  });
+});

--- a/tests/unit/utils/missing-plugin-test.js
+++ b/tests/unit/utils/missing-plugin-test.js
@@ -1,0 +1,10 @@
+import missingPlugin from '../../../utils/missing-plugin';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | missing plugin');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  var result = missingPlugin();
+  assert.ok(result);
+});


### PR DESCRIPTION
Adds support for alerts, confirm and prompt dialogs.
